### PR TITLE
Implement pricing helpers for AWS rates

### DIFF
--- a/src/aws_pricer/pricing.py
+++ b/src/aws_pricer/pricing.py
@@ -1,3 +1,180 @@
-"""Pricing module placeholder."""
+"""Helpers for retrieving AWS Pricing and Savings Plans rates."""
 
-# Implementation coming soon.
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from decimal import Decimal, InvalidOperation
+from typing import Any, Final
+
+import boto3
+
+_PRICING_REGION: Final[str] = "us-east-1"
+_EC2_SERVICE_CODE: Final[str] = "AmazonEC2"
+_TERM_MATCH: Final[str] = "TERM_MATCH"
+_ONDEMAND_KEY: Final[str] = "OnDemand"
+_PRICE_DIMENSIONS_KEY: Final[str] = "priceDimensions"
+_PRICE_PER_UNIT_KEY: Final[str] = "pricePerUnit"
+_USD: Final[str] = "USD"
+_SUPPORTED_RATE_UNITS: Final[set[str]] = {"Hrs", "Hours"}
+_SAVINGS_PLAN_DURATION_LABELS: Final[dict[int, str]] = {
+    31_536_000: "1y",
+    94_608_000: "3y",
+}
+
+
+def get_ondemand_usd_per_hour(*, instance_type: str, region: str, os: str) -> Decimal:
+    """Return the on-demand hourly USD price for an EC2 instance."""
+
+    client = boto3.client("pricing", region_name=_PRICING_REGION)
+    response = client.get_products(
+        ServiceCode=_EC2_SERVICE_CODE,
+        Filters=[
+            {"Type": _TERM_MATCH, "Field": "instanceType", "Value": instance_type},
+            {"Type": _TERM_MATCH, "Field": "regionCode", "Value": region},
+            {"Type": _TERM_MATCH, "Field": "operatingSystem", "Value": os},
+        ],
+        MaxResults=1,
+    )
+
+    price_list = response.get("PriceList") or []
+    for entry in price_list:
+        try:
+            price_item = _load_price_list_entry(entry)
+        except (TypeError, json.JSONDecodeError) as exc:  # pragma: no cover - defensive
+            raise ValueError("Invalid pricing payload returned by AWS Pricing API") from exc
+
+        price = _extract_ondemand_usd(price_item)
+        if price is not None:
+            return price
+
+    raise ValueError("No on-demand pricing data returned by AWS Pricing API")
+
+
+def get_savingsplan_no_upfront_usd_per_hour(
+    *,
+    instance_type: str,
+    region: str,
+    os: str,
+    plan_type: str,
+    savingsPlanPaymentOptions: str | Iterable[str] = "No Upfront",
+) -> dict[str, Decimal]:
+    """Return 1-year and 3-year Savings Plans hourly USD prices."""
+
+    client = boto3.client("savingsplans", region_name=_PRICING_REGION)
+    response = client.describe_savings_plans_offering_rates(
+        savingsPlanPaymentOptions=_coerce_payment_options(savingsPlanPaymentOptions),
+        filters=[
+            {"name": "instanceType", "values": [instance_type]},
+            {"name": "region", "values": [region]},
+            {"name": "productDescription", "values": [os]},
+            {"name": "planType", "values": [plan_type]},
+        ],
+    )
+
+    search_results = response.get("searchResults") or []
+    rates: dict[str, Decimal] = {}
+    for result in search_results:
+        if not isinstance(result, Mapping):  # pragma: no cover - defensive
+            continue
+
+        if result.get("currency") != _USD:
+            continue
+
+        duration = result.get("durationSeconds")
+        if not isinstance(duration, int):
+            continue
+
+        label = _SAVINGS_PLAN_DURATION_LABELS.get(duration)
+        if label is None:
+            continue
+
+        unit = result.get("unit")
+        if isinstance(unit, str) and unit not in _SUPPORTED_RATE_UNITS:
+            continue
+
+        rate_value = result.get("rate")
+        if not isinstance(rate_value, str):
+            continue
+
+        try:
+            rate_decimal = Decimal(rate_value)
+        except InvalidOperation as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Invalid Savings Plans rate '{rate_value}' returned by AWS") from exc
+
+        current = rates.get(label)
+        if current is None or rate_decimal < current:
+            rates[label] = rate_decimal
+
+    if {"1y", "3y"} - rates.keys():
+        raise ValueError("Savings Plans rates for both 1y and 3y are required")
+
+    return rates
+
+
+def _load_price_list_entry(entry: Any) -> Mapping[str, Any]:
+    if isinstance(entry, str):
+        loaded = json.loads(entry)
+    elif isinstance(entry, Mapping):
+        loaded = entry
+    else:  # pragma: no cover - defensive
+        raise TypeError(f"Unexpected price list entry type: {type(entry)!r}")
+
+    if not isinstance(loaded, Mapping):  # pragma: no cover - defensive
+        raise TypeError("Decoded price list entry is not a mapping")
+
+    return loaded
+
+
+def _extract_ondemand_usd(price_item: Mapping[str, Any]) -> Decimal | None:
+    terms = price_item.get("terms")
+    if not isinstance(terms, Mapping):
+        return None
+
+    ondemand_terms = terms.get(_ONDEMAND_KEY)
+    if not isinstance(ondemand_terms, Mapping):
+        return None
+
+    for term in ondemand_terms.values():
+        if not isinstance(term, Mapping):
+            continue
+
+        dimensions = term.get(_PRICE_DIMENSIONS_KEY)
+        if not isinstance(dimensions, Mapping):
+            continue
+
+        for dimension in dimensions.values():
+            if not isinstance(dimension, Mapping):
+                continue
+
+            unit = dimension.get("unit")
+            if isinstance(unit, str) and unit not in _SUPPORTED_RATE_UNITS:
+                continue
+
+            price_per_unit = dimension.get(_PRICE_PER_UNIT_KEY)
+            if not isinstance(price_per_unit, Mapping):
+                continue
+
+            usd_value = price_per_unit.get(_USD)
+            if not isinstance(usd_value, str):
+                continue
+
+            try:
+                return Decimal(usd_value)
+            except InvalidOperation as exc:  # pragma: no cover - defensive
+                raise ValueError(
+                    f"Invalid on-demand USD price '{usd_value}' returned by AWS"
+                ) from exc
+
+    return None
+
+
+def _coerce_payment_options(value: str | Iterable[str]) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+
+    options = list(value)
+    if not all(isinstance(option, str) for option in options):  # pragma: no cover - defensive
+        raise TypeError("Savings Plan payment options must be strings")
+
+    return options

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for aws_pricer."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))

--- a/tests/fixtures/pricing.py
+++ b/tests/fixtures/pricing.py
@@ -1,0 +1,120 @@
+"""Test fixtures for :mod:`aws_pricer.pricing` module.
+
+Resources
+---------
+- Boto3 Pricing client documentation: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/pricing.html
+  Sample query::
+
+      import boto3
+
+      pricing = boto3.client("pricing", region_name="us-east-1")
+      response = pricing.get_products(
+          ServiceCode="AmazonEC2",
+          Filters=[
+              {"Type": "TERM_MATCH", "Field": "instanceType", "Value": "m6i.large"},
+              {"Type": "TERM_MATCH", "Field": "regionCode", "Value": "ap-southeast-2"},
+              {"Type": "TERM_MATCH", "Field": "operatingSystem", "Value": "Linux"},
+          ],
+          MaxResults=1,
+      )
+
+  Example response payload (abbreviated)::
+
+      {
+          "PriceList": [
+              (
+                  "{\"product\": {\"productFamily\": \"Compute Instance\"}, ...}"
+              )
+          ],
+          "FormatVersion": "aws_v1"
+      }
+
+- Boto3 Savings Plans client documentation: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/savingsplans.html
+  Sample query::
+
+      savingsplans = boto3.client("savingsplans", region_name="us-east-1")
+      response = savingsplans.describe_savings_plans_offering_rates(
+          savingsPlanPaymentOptions=["No Upfront"],
+          filters=[
+              {"name": "instanceType", "values": ["m6i.large"]},
+              {"name": "region", "values": ["ap-southeast-2"]},
+              {"name": "productDescription", "values": ["Linux"]},
+              {"name": "planType", "values": ["Compute"]},
+          ],
+      )
+
+  Example response entry (abbreviated)::
+
+      {
+          "currency": "USD",
+          "durationSeconds": 31536000,
+          "rate": "0.052",
+          "savingsPlanArn": "arn:aws:savingsplans:sample",
+          "savingsPlanType": "COMPUTE",
+          "serviceCode": "AmazonEC2",
+          "unit": "Hrs"
+      }
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def make_price_list_entry(*, usd_per_hour: str = "0.096", unit: str = "Hrs") -> str:
+    """Return a minimal Pricing API price list entry as a JSON string."""
+    return json.dumps(
+        {
+            "product": {
+                "productFamily": "Compute Instance",
+                "sku": "SAMPLE-SKU",
+                "attributes": {
+                    "instanceType": "m6i.large",
+                    "regionCode": "ap-southeast-2",
+                    "operatingSystem": "Linux",
+                },
+            },
+            "terms": {
+                "OnDemand": {
+                    "SAMPLE-SKU.Ondemand": {
+                        "priceDimensions": {
+                            "SAMPLE-SKU.DIMENSION": {
+                                "unit": unit,
+                                "pricePerUnit": {"USD": usd_per_hour},
+                                "description": "Sample description",
+                                "beginRange": "0",
+                                "endRange": "Inf",
+                            }
+                        },
+                        "sku": "SAMPLE-SKU",
+                        "effectiveDate": "2024-01-01T00:00:00Z",
+                        "offerTermCode": "JRTCKXETXF",
+                    }
+                }
+            },
+            "serviceCode": "AmazonEC2",
+        }
+    )
+
+
+def make_savings_plan_result(
+    *,
+    usd_per_hour: str,
+    duration_seconds: int,
+    currency: str = "USD",
+    unit: str = "Hrs",
+) -> dict[str, Any]:
+    """Return a minimal Savings Plans offering rate search result."""
+    return {
+        "currency": currency,
+        "durationSeconds": duration_seconds,
+        "operation": "RunInstances",
+        "productType": "Compute",
+        "rate": usd_per_hour,
+        "savingsPlanArn": "arn:aws:savingsplans:sample",
+        "savingsPlanType": "COMPUTE",
+        "serviceCode": "AmazonEC2",
+        "unit": unit,
+        "usageType": "APAC-Sydney-BoxUsage:m6i.large",
+    }

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import types
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from aws_pricer import pricing
+from tests.fixtures import pricing as pricing_fixtures
+
+
+class DummyPricingClient:
+    def __init__(self, response: dict[str, Any]):
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def get_products(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return self.response
+
+
+class DummySavingsPlansClient:
+    def __init__(self, response: dict[str, Any]):
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def describe_savings_plans_offering_rates(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return self.response
+
+
+def _patch_boto3(monkeypatch: pytest.MonkeyPatch, fake_client: Any) -> None:
+    """Patch the boto3 module used in aws_pricer.pricing."""
+
+    def _client(service_name: str, *, region_name: str | None = None) -> Any:
+        return fake_client(service_name=service_name, region_name=region_name)
+
+    monkeypatch.setattr(
+        pricing,
+        "boto3",
+        types.SimpleNamespace(client=_client),
+        raising=False,
+    )
+
+
+def test_get_ondemand_usd_per_hour_fetches_hourly_rate(monkeypatch: pytest.MonkeyPatch) -> None:
+    if not hasattr(pricing, "get_ondemand_usd_per_hour"):
+        pytest.fail("pricing.get_ondemand_usd_per_hour is not implemented")
+
+    price_list_entry = pricing_fixtures.make_price_list_entry(usd_per_hour="0.096")
+    response = {"PriceList": [price_list_entry], "FormatVersion": "aws_v1"}
+    client = DummyPricingClient(response=response)
+
+    def _fake_client(service_name: str, region_name: str | None = None) -> DummyPricingClient:
+        assert service_name == "pricing"
+        assert region_name == "us-east-1"
+        return client
+
+    _patch_boto3(monkeypatch, fake_client=_fake_client)
+
+    result = pricing.get_ondemand_usd_per_hour(
+        instance_type="m6i.large",
+        region="ap-southeast-2",
+        os="Linux",
+    )
+
+    assert result == Decimal("0.096")
+    assert client.calls, "Expected aws_pricer.pricing to invoke get_products"
+    call_kwargs = client.calls[-1]
+
+    assert call_kwargs.get("ServiceCode") == "AmazonEC2"
+    filters = {(
+        filter_entry.get("Field"),
+        filter_entry.get("Type"),
+    ): filter_entry.get("Value") for filter_entry in call_kwargs.get("Filters", [])}
+    assert filters[("instanceType", "TERM_MATCH")] == "m6i.large"
+    assert filters[("regionCode", "TERM_MATCH")] == "ap-southeast-2"
+    assert filters[("operatingSystem", "TERM_MATCH")] == "Linux"
+    assert call_kwargs.get("MaxResults") == 1
+
+
+def test_get_ondemand_usd_per_hour_errors_when_no_prices(monkeypatch: pytest.MonkeyPatch) -> None:
+    if not hasattr(pricing, "get_ondemand_usd_per_hour"):
+        pytest.fail("pricing.get_ondemand_usd_per_hour is not implemented")
+
+    client = DummyPricingClient(response={"PriceList": [], "FormatVersion": "aws_v1"})
+
+    def _fake_client(service_name: str, region_name: str | None = None) -> DummyPricingClient:
+        assert service_name == "pricing"
+        assert region_name == "us-east-1"
+        return client
+
+    _patch_boto3(monkeypatch, fake_client=_fake_client)
+
+    with pytest.raises(ValueError, match="No on-demand pricing data"):
+        pricing.get_ondemand_usd_per_hour(
+            instance_type="m6i.large",
+            region="ap-southeast-2",
+            os="Linux",
+        )
+
+
+def test_get_savingsplan_no_upfront_usd_per_hour_parses_rates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if not hasattr(pricing, "get_savingsplan_no_upfront_usd_per_hour"):
+        pytest.fail("pricing.get_savingsplan_no_upfront_usd_per_hour is not implemented")
+
+    response = {
+        "searchResults": [
+            pricing_fixtures.make_savings_plan_result(
+                usd_per_hour="0.052", duration_seconds=31_536_000
+            ),
+            pricing_fixtures.make_savings_plan_result(
+                usd_per_hour="0.047", duration_seconds=94_608_000
+            ),
+        ]
+    }
+    client = DummySavingsPlansClient(response=response)
+
+    def _fake_client(service_name: str, region_name: str | None = None) -> DummySavingsPlansClient:
+        assert service_name == "savingsplans"
+        return client
+
+    _patch_boto3(monkeypatch, fake_client=_fake_client)
+
+    result = pricing.get_savingsplan_no_upfront_usd_per_hour(
+        instance_type="m6i.large",
+        region="ap-southeast-2",
+        os="Linux",
+        plan_type="Compute",
+        savingsPlanPaymentOptions="No Upfront",
+    )
+
+    assert result == {"1y": Decimal("0.052"), "3y": Decimal("0.047")}
+    assert client.calls, "Expected aws_pricer.pricing to call describe_savings_plans_offering_rates"
+    call_kwargs = client.calls[-1]
+
+    assert call_kwargs.get("savingsPlanPaymentOptions") == ["No Upfront"]
+    filters: dict[str | None, tuple[str, ...]] = {}
+    for entry in call_kwargs.get("filters", []):
+        name = entry.get("name") or entry.get("Name")
+        values = entry.get("values") or entry.get("Values") or []
+        filters[name] = tuple(values)
+
+    assert filters.get("instanceType") == ("m6i.large",)
+    assert filters.get("region") == ("ap-southeast-2",)
+    assert filters.get("productDescription") == ("Linux",)
+    assert filters.get("planType") == ("Compute",)
+
+
+def test_get_savingsplan_no_upfront_usd_per_hour_requires_one_and_three_year_rates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if not hasattr(pricing, "get_savingsplan_no_upfront_usd_per_hour"):
+        pytest.fail("pricing.get_savingsplan_no_upfront_usd_per_hour is not implemented")
+
+    response = {
+        "searchResults": [
+            pricing_fixtures.make_savings_plan_result(
+                usd_per_hour="0.052", duration_seconds=31_536_000
+            )
+        ]
+    }
+    client = DummySavingsPlansClient(response=response)
+
+    def _fake_client(service_name: str, region_name: str | None = None) -> DummySavingsPlansClient:
+        assert service_name == "savingsplans"
+        return client
+
+    _patch_boto3(monkeypatch, fake_client=_fake_client)
+
+    with pytest.raises(ValueError, match="Savings Plans rates for both 1y and 3y are required"):
+        pricing.get_savingsplan_no_upfront_usd_per_hour(
+            instance_type="m6i.large",
+            region="ap-southeast-2",
+            os="Linux",
+            plan_type="Compute",
+            savingsPlanPaymentOptions="No Upfront",
+        )


### PR DESCRIPTION
## Summary
- document boto3 Pricing and Savings Plans resources in the pricing fixtures module
- provide example queries and responses to guide future pricing helper implementations
- implement pricing helpers that retrieve on-demand and Savings Plans USD hourly rates with defensive parsing and validation

## Testing
- ruff check .
- mypy src
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d1e65a0cf0832da5fb766888b0ab0a