### PR TITLE
Fix savings plan lookups for compute plans

### DIFF
--- a/tests/fixtures/pricing.py
+++ b/tests/fixtures/pricing.py
@@ -35,24 +35,28 @@ Resources
       savingsplans = boto3.client("savingsplans", region_name="us-east-1")
       response = savingsplans.describe_savings_plans_offering_rates(
           savingsPlanPaymentOptions=["No Upfront"],
+          savingsPlanTypes=["Compute"],
           filters=[
               {"name": "instanceType", "values": ["m6i.large"]},
               {"name": "region", "values": ["ap-southeast-2"]},
-              {"name": "productDescription", "values": ["Linux"]},
-              {"name": "planType", "values": ["Compute"]},
+              {"name": "productDescription", "values": ["Linux/UNIX"]},
           ],
       )
 
   Example response entry (abbreviated)::
 
       {
-          "currency": "USD",
-          "durationSeconds": 31536000,
+          "savingsPlanOffering": {
+              "currency": "USD",
+              "durationSeconds": 31536000,
+              "planType": "Compute",
+          },
+          "properties": [
+              {"name": "productDescription", "value": "Linux/UNIX"},
+              {"name": "tenancy", "value": "shared"},
+          ],
           "rate": "0.052",
-          "savingsPlanArn": "arn:aws:savingsplans:sample",
-          "savingsPlanType": "COMPUTE",
-          "serviceCode": "AmazonEC2",
-          "unit": "Hrs"
+          "unit": "Hrs",
       }
 """
 
@@ -104,17 +108,29 @@ def make_savings_plan_result(
     duration_seconds: int,
     currency: str = "USD",
     unit: str = "Hrs",
+    product_description: str = "Linux/UNIX",
+    tenancy: str = "shared",
 ) -> dict[str, Any]:
     """Return a minimal Savings Plans offering rate search result."""
     return {
-        "currency": currency,
-        "durationSeconds": duration_seconds,
-        "operation": "RunInstances",
-        "productType": "Compute",
+        "savingsPlanOffering": {
+            "offeringId": "sample-offering-id",
+            "paymentOption": "No Upfront",
+            "planType": "Compute",
+            "durationSeconds": duration_seconds,
+            "currency": currency,
+        },
         "rate": usd_per_hour,
-        "savingsPlanArn": "arn:aws:savingsplans:sample",
-        "savingsPlanType": "COMPUTE",
-        "serviceCode": "AmazonEC2",
         "unit": unit,
+        "productType": "EC2",
+        "serviceCode": "AmazonEC2",
         "usageType": "APAC-Sydney-BoxUsage:m6i.large",
+        "operation": "RunInstances",
+        "properties": [
+            {"name": "instanceFamily", "value": "m6i"},
+            {"name": "productDescription", "value": product_description},
+            {"name": "instanceType", "value": "m6i.large"},
+            {"name": "tenancy", "value": tenancy},
+            {"name": "region", "value": "ap-southeast-2"},
+        ],
     }

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -138,6 +138,7 @@ def test_get_savingsplan_no_upfront_usd_per_hour_parses_rates(
     call_kwargs = client.calls[-1]
 
     assert call_kwargs.get("savingsPlanPaymentOptions") == ["No Upfront"]
+    assert call_kwargs.get("savingsPlanTypes") == ["Compute"]
     filters: dict[str | None, tuple[str, ...]] = {}
     for entry in call_kwargs.get("filters", []):
         name = entry.get("name") or entry.get("Name")
@@ -146,8 +147,8 @@ def test_get_savingsplan_no_upfront_usd_per_hour_parses_rates(
 
     assert filters.get("instanceType") == ("m6i.large",)
     assert filters.get("region") == ("ap-southeast-2",)
-    assert filters.get("productDescription") == ("Linux",)
-    assert filters.get("planType") == ("Compute",)
+    assert filters.get("productDescription") == ("Linux", "Linux/UNIX")
+    assert "planType" not in filters
 
 
 def test_get_savingsplan_no_upfront_usd_per_hour_requires_one_and_three_year_rates(


### PR DESCRIPTION
## Summary
- query Savings Plans offerings with the correct `savingsPlanTypes` parameter and normalise Linux product descriptions to match AWS data
- parse currency, duration and product description from the nested offering/properties structures before extracting the best rates
- refresh tests and fixtures to mirror the Savings Plans payload returned by AWS

## Testing
- ruff check .
- mypy src
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1fd372104832d82f2311fcf19f82b