### PR TITLE
Refine EC2 on-demand pricing filters

### DIFF
--- a/src/aws_pricer/pricing.py
+++ b/src/aws_pricer/pricing.py
@@ -27,17 +27,29 @@ _SAVINGS_PLAN_PRODUCT_DESCRIPTION_ALIASES: Final[dict[str, tuple[str, ...]]] = {
 }
 
 
+_ONDEMAND_FILTERS: Final[tuple[tuple[str, str], ...]] = (
+    ("tenancy", "Shared"),
+    ("capacitystatus", "Used"),
+    ("preInstalledSw", "NA"),
+)
+
+
 def get_ondemand_usd_per_hour(*, instance_type: str, region: str, os: str) -> Decimal:
     """Return the on-demand hourly USD price for an EC2 instance."""
 
     client = boto3.client("pricing", region_name=_PRICING_REGION)
+    filters = [
+        {"Type": _TERM_MATCH, "Field": "instanceType", "Value": instance_type},
+        {"Type": _TERM_MATCH, "Field": "regionCode", "Value": region},
+        {"Type": _TERM_MATCH, "Field": "operatingSystem", "Value": os},
+    ]
+    filters.extend(
+        {"Type": _TERM_MATCH, "Field": field, "Value": value}
+        for field, value in _ONDEMAND_FILTERS
+    )
     response = client.get_products(
         ServiceCode=_EC2_SERVICE_CODE,
-        Filters=[
-            {"Type": _TERM_MATCH, "Field": "instanceType", "Value": instance_type},
-            {"Type": _TERM_MATCH, "Field": "regionCode", "Value": region},
-            {"Type": _TERM_MATCH, "Field": "operatingSystem", "Value": os},
-        ],
+        Filters=filters,
         MaxResults=1,
     )
 

--- a/tests/fixtures/pricing.py
+++ b/tests/fixtures/pricing.py
@@ -14,6 +14,9 @@ Resources
               {"Type": "TERM_MATCH", "Field": "instanceType", "Value": "m6i.large"},
               {"Type": "TERM_MATCH", "Field": "regionCode", "Value": "ap-southeast-2"},
               {"Type": "TERM_MATCH", "Field": "operatingSystem", "Value": "Linux"},
+              {"Type": "TERM_MATCH", "Field": "tenancy", "Value": "Shared"},
+              {"Type": "TERM_MATCH", "Field": "capacitystatus", "Value": "Used"},
+              {"Type": "TERM_MATCH", "Field": "preInstalledSw", "Value": "NA"},
           ],
           MaxResults=1,
       )
@@ -77,6 +80,9 @@ def make_price_list_entry(*, usd_per_hour: str = "0.096", unit: str = "Hrs") -> 
                     "instanceType": "m6i.large",
                     "regionCode": "ap-southeast-2",
                     "operatingSystem": "Linux",
+                    "tenancy": "Shared",
+                    "capacitystatus": "Used",
+                    "preInstalledSw": "NA",
                 },
             },
             "terms": {

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -77,6 +77,9 @@ def test_get_ondemand_usd_per_hour_fetches_hourly_rate(monkeypatch: pytest.Monke
     assert filters[("instanceType", "TERM_MATCH")] == "m6i.large"
     assert filters[("regionCode", "TERM_MATCH")] == "ap-southeast-2"
     assert filters[("operatingSystem", "TERM_MATCH")] == "Linux"
+    assert filters[("tenancy", "TERM_MATCH")] == "Shared"
+    assert filters[("capacitystatus", "TERM_MATCH")] == "Used"
+    assert filters[("preInstalledSw", "TERM_MATCH")] == "NA"
     assert call_kwargs.get("MaxResults") == 1
 
 


### PR DESCRIPTION
## Summary
- tighten the EC2 on-demand pricing filters to target shared, used instances with no preinstalled software
- update the pricing fixtures and unit tests to reflect the stricter filter set

## Testing
- ruff check .
- mypy src
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d23f1b1648832d9b6cd068f4c4c5d1