### PR TITLE
Add license model filters for EC2 on-demand pricing

### DIFF
--- a/src/aws_pricer/pricing.py
+++ b/src/aws_pricer/pricing.py
@@ -32,6 +32,10 @@ _ONDEMAND_FILTERS: Final[tuple[tuple[str, str], ...]] = (
     ("capacitystatus", "Used"),
     ("preInstalledSw", "NA"),
 )
+_LICENSE_MODEL_BY_OS: Final[dict[str, str]] = {
+    "linux": "No License required",
+    "windows": "License Included",
+}
 
 
 def get_ondemand_usd_per_hour(*, instance_type: str, region: str, os: str) -> Decimal:
@@ -43,6 +47,11 @@ def get_ondemand_usd_per_hour(*, instance_type: str, region: str, os: str) -> De
         {"Type": _TERM_MATCH, "Field": "regionCode", "Value": region},
         {"Type": _TERM_MATCH, "Field": "operatingSystem", "Value": os},
     ]
+    license_model = _license_model_for_os(os)
+    if license_model is not None:
+        filters.append(
+            {"Type": _TERM_MATCH, "Field": "licenseModel", "Value": license_model}
+        )
     filters.extend(
         {"Type": _TERM_MATCH, "Field": field, "Value": value}
         for field, value in _ONDEMAND_FILTERS
@@ -209,6 +218,10 @@ def _coerce_payment_options(value: str | Iterable[str]) -> list[str]:
         raise TypeError("Savings Plan payment options must be strings")
 
     return options
+
+
+def _license_model_for_os(os: str) -> str | None:
+    return _LICENSE_MODEL_BY_OS.get(os.casefold())
 
 
 def _savings_plan_product_descriptions(os: str) -> list[str]:

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -77,10 +77,49 @@ def test_get_ondemand_usd_per_hour_fetches_hourly_rate(monkeypatch: pytest.Monke
     assert filters[("instanceType", "TERM_MATCH")] == "m6i.large"
     assert filters[("regionCode", "TERM_MATCH")] == "ap-southeast-2"
     assert filters[("operatingSystem", "TERM_MATCH")] == "Linux"
+    assert filters[("licenseModel", "TERM_MATCH")] == "No License required"
     assert filters[("tenancy", "TERM_MATCH")] == "Shared"
     assert filters[("capacitystatus", "TERM_MATCH")] == "Used"
     assert filters[("preInstalledSw", "TERM_MATCH")] == "NA"
     assert call_kwargs.get("MaxResults") == 1
+
+
+def test_get_ondemand_usd_per_hour_sets_windows_license_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if not hasattr(pricing, "get_ondemand_usd_per_hour"):
+        pytest.fail("pricing.get_ondemand_usd_per_hour is not implemented")
+
+    price_list_entry = pricing_fixtures.make_price_list_entry(usd_per_hour="0.192")
+    response = {"PriceList": [price_list_entry], "FormatVersion": "aws_v1"}
+    client = DummyPricingClient(response=response)
+
+    def _fake_client(service_name: str, region_name: str | None = None) -> DummyPricingClient:
+        assert service_name == "pricing"
+        assert region_name == "us-east-1"
+        return client
+
+    _patch_boto3(monkeypatch, fake_client=_fake_client)
+
+    result = pricing.get_ondemand_usd_per_hour(
+        instance_type="m6i.large",
+        region="us-west-2",
+        os="Windows",
+    )
+
+    assert result == Decimal("0.192")
+    assert client.calls, "Expected aws_pricer.pricing to invoke get_products"
+    call_kwargs = client.calls[-1]
+
+    filters = {
+        (
+            filter_entry.get("Field"),
+            filter_entry.get("Type"),
+        ): filter_entry.get("Value")
+        for filter_entry in call_kwargs.get("Filters", [])
+    }
+
+    assert filters[("licenseModel", "TERM_MATCH")] == "License Included"
 
 
 def test_get_ondemand_usd_per_hour_errors_when_no_prices(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add a license model mapping for Linux and Windows operating systems
- include the licenseModel TERM_MATCH filter in EC2 on-demand pricing queries
- expand pricing tests to cover Linux and Windows license expectations

## Testing
- ruff check .
- mypy src
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d249d83d88832da5d01a2829dd544b