### PR TITLE
Filter EC2 pricing by No License required license model

### DIFF
--- a/src/aws_pricer/pricing.py
+++ b/src/aws_pricer/pricing.py
@@ -32,10 +32,6 @@ _ONDEMAND_FILTERS: Final[tuple[tuple[str, str], ...]] = (
     ("capacitystatus", "Used"),
     ("preInstalledSw", "NA"),
 )
-_LICENSE_MODEL_BY_OS: Final[dict[str, str]] = {
-    "linux": "No License required",
-    "windows": "License Included",
-}
 
 
 def get_ondemand_usd_per_hour(*, instance_type: str, region: str, os: str) -> Decimal:
@@ -46,12 +42,8 @@ def get_ondemand_usd_per_hour(*, instance_type: str, region: str, os: str) -> De
         {"Type": _TERM_MATCH, "Field": "instanceType", "Value": instance_type},
         {"Type": _TERM_MATCH, "Field": "regionCode", "Value": region},
         {"Type": _TERM_MATCH, "Field": "operatingSystem", "Value": os},
+        {"Type": _TERM_MATCH, "Field": "licenseModel", "Value": "No License required"},
     ]
-    license_model = _license_model_for_os(os)
-    if license_model is not None:
-        filters.append(
-            {"Type": _TERM_MATCH, "Field": "licenseModel", "Value": license_model}
-        )
     filters.extend(
         {"Type": _TERM_MATCH, "Field": field, "Value": value}
         for field, value in _ONDEMAND_FILTERS
@@ -218,12 +210,6 @@ def _coerce_payment_options(value: str | Iterable[str]) -> list[str]:
         raise TypeError("Savings Plan payment options must be strings")
 
     return options
-
-
-def _license_model_for_os(os: str) -> str | None:
-    return _LICENSE_MODEL_BY_OS.get(os.casefold())
-
-
 def _savings_plan_product_descriptions(os: str) -> list[str]:
     aliases = _SAVINGS_PLAN_PRODUCT_DESCRIPTION_ALIASES.get(os)
     if aliases is None:


### PR DESCRIPTION
## Summary
- remove the OS-specific license model lookup and always request "No License required" EC2 prices
- update the on-demand pricing test expectations to match the simplified license model filter

## Testing
- ruff check .
- mypy src
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d250e20a40832d89640545d5cc8d38